### PR TITLE
Conda recipe tweaks

### DIFF
--- a/conda-recipe/README
+++ b/conda-recipe/README
@@ -1,7 +1,7 @@
 These recipe files can build two different packages:
 
-Package name        Python module
-------------        ---------------------------------
+Package name                            Python module
+------------                            ---------------------------------
 multi-hypotheses-tracking-with-cplex    import multiHypoTracking_with_cplex as multiHypoTracking
 multi-hypotheses-tracking-with-gurobi   import multiHypoTracking_with_gurobi as multiHypoTracking
 

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -10,6 +10,10 @@ if [[ "$WITH_CPLEX" == "0" ]]; then
     WITH_CPLEX=""
 fi
 
+if [[ "$WITH_GUROBI" == "0" ]]; then
+    WITH_GUROBI=""
+fi
+
 # Platform-specific dylib extension
 if [ $(uname) == "Darwin" ]; then
     export DYLIB="dylib"

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -22,12 +22,7 @@ if [[ "$WITH_CPLEX" == "" ]]; then
     CPLEX_ARGS=""
     LINKER_FLAGS=""
 else
-    if [ $(echo $PREFIX | grep -q envs)$? -eq 0 ]; then
-        ROOT_ENV_PREFIX="${PREFIX}/../.."
-    else
-        ROOT_ENV_PREFIX="${PREFIX}"
-    fi
-    CPLEX_LOCATION_CACHE_FILE="${ROOT_ENV_PREFIX}/share/cplex-root-dir.path"
+    CPLEX_LOCATION_CACHE_FILE="$(conda info --root)/share/cplex-root-dir.path"
     
     if [[ "$CPLEX_ROOT_DIR" == "<UNDEFINED>" || "$CPLEX_ROOT_DIR" == "" ]]; then
         # Look for CPLEX_ROOT_DIR in the cplex-shared cache file.

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -102,7 +102,19 @@ else
     GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_ROOT_DIR=${GUROBI_ROOT_DIR}"
     GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_LIBRARY=$(ls ${GUROBI_ROOT_DIR}/lib/libgurobi*.so)"
     GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_INCLUDE_DIR=${GUROBI_ROOT_DIR}/include"
-    GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_CXX_LIBRARY=${GUROBI_ROOT_DIR}/lib/libgurobi_c++.a"
+    if [ $(uname) == "Darwin" ]; then
+        # Note: For Mac, the nice Gurobi people provide two versions of the gurobi library,
+        #       depending on which version of the C++ std library you need to use:
+        #       - For libstdc++ (from the GNU people), use libgurobi_stdc++.a
+        #       - For libc++    (from the clang people), use libgurobi_c++.a
+        #       We use gcc (even on Mac), so we use the libstdc++ version.
+        GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_CXX_LIBRARY=${GUROBI_ROOT_DIR}/lib/libgurobi_stdc++.a"
+    else
+        # Only one choice on Linux. It works with libstdc++ (from the GNU people).
+        # (The naming convention isn't consistent with the name on Mac, but that's okay.)
+        GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_CXX_LIBRARY=${GUROBI_ROOT_DIR}/lib/libgurobi_c++.a"
+    fi
+
     SUFFIX="_with_gurobi"
 fi
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,10 +1,12 @@
 {% if not WITH_CPLEX is defined %}
-  {% set WITH_CPLEX = False %}
+  {% set WITH_CPLEX = 0 %}
 {% endif %}
+{% set WITH_CPLEX = WITH_CPLEX|int %}
 
 {% if not WITH_GUROBI is defined %}
-  {% set WITH_GUROBI = False %}
+  {% set WITH_GUROBI = 0 %}
 {% endif %}
+{% set WITH_GUROBI = WITH_GUROBI|int %}
 
 package:
   {% if WITH_CPLEX %}
@@ -25,13 +27,13 @@ package:
     version: {{tagged_version}}
 
 source:
-  git_url: https://github.com/chaubold/multiHypothesesTracking
-  git_tag: HEAD
+  path: ../
 
 build:
   detect_binary_files_with_prefix: true
 
-  string: py{{CONDA_PY}}_g{{GIT_FULL_HASH[:7]}}
+  number: 0
+  string: py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
 
   script_env:
     - WITH_CPLEX
@@ -49,11 +51,11 @@ requirements:
     - opengm-structured-learning-headers
     - python {{PY_VER}}*
 
-    {% if WITH_CPLEX is defined and WITH_CPLEX %}
+    {% if WITH_CPLEX %}
     - cplex-shared # Need to make sure that cplex dylibs exist
     {% endif %}
 
-    {% if WITH_GUROBI is defined and WITH_GUROBI %}
+    {% if WITH_GUROBI %}
     - gurobi-symlink
     {% endif %}
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -30,8 +30,6 @@ source:
   path: ../
 
 build:
-  detect_binary_files_with_prefix: true
-
   number: 0
   string: py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,7 +43,6 @@ build:
 
 requirements:
   build:
-    - libgcc
     - gcc 4.8.5 # [linux]
     - gcc 4.8.5 # [osx]
     - patchelf # [linux]
@@ -60,7 +59,7 @@ requirements:
     {% endif %}
 
   run:
-    - libgcc
+    - libgcc 4.8.5
     - patchelf # [linux]
     - boost 1.55.0
     - python {{PY_VER}}*


### PR DESCRIPTION
I made some changes to the conda recipe.  The commit log says it all, but here's the summary:

- On Mac, use the libstdc++ version of libgurobi_c++
- Use the local git repo instead of fetching from a git_url
- Minor changes to support conda-build 2.0
