### PR TITLE
Use system compiler linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.6)
 PROJECT(multiHypoTracking)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_extensions/)
 
+set ( LINUX FALSE )
+if(UNIX AND NOT APPLE)
+    set( LINUX TRUE )
+endif()
+
 # --------------------------------------------------------------
 # dependencies
 find_package( Cplex )
@@ -27,7 +32,12 @@ else()
         # Following flags are required by CPLEX 128:
         # the --no-as-needed ... --as-needed is needed :) because the cplex
         # guys forgot to link against libdl
-        set( CPLEX_LINKER_FLAGS "-Wl,--no-as-needed -ldl -Wl,--as-needed" )
+        if ( LINUX )
+            set( CPLEX_LINKER_FLAGS "-Wl,--no-as-needed -ldl -Wl,--as-needed" )
+        else()
+            set( CPLEX_LINKER_FLAGS "-ldl" )
+        endif()
+
         set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CPLEX_LINKER_FLAGS}" )
     else()
     	message(FATAL_ERROR "No optimizer found at all!")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ else()
 	    # CPLEX switch to be compatible with STL
 		ADD_DEFINITIONS(-DIL_STD)
         # Following flags are required by CPLEX 128:
-        set( CPLEX_LINKER_FLAGS "-ldl" )
+        # the --no-as-needed ... --as-needed is needed :) because the cplex
+        # guys forgot to link against libdl
+        set( CPLEX_LINKER_FLAGS "-Wl,--no-as-needed -ldl -Wl,--as-needed" )
         set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CPLEX_LINKER_FLAGS}" )
     else()
     	message(FATAL_ERROR "No optimizer found at all!")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ else()
 	    add_definitions(-DWITH_CPLEX)
 	    # CPLEX switch to be compatible with STL
 		ADD_DEFINITIONS(-DIL_STD)
+        # Following flags are required by CPLEX 128:
+        set( CPLEX_LINKER_FLAGS "-ldl" )
+        set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${CPLEX_LINKER_FLAGS}" )
     else()
     	message(FATAL_ERROR "No optimizer found at all!")
     endif()

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -140,7 +140,10 @@ else
     CXX=g++
     export DYLIB="so"
     LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
-    CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
+    # Check which gcxx abi to use; for compatibility with libs build with gcc < 5:
+    if [[ ${DO_NOT_BUILD_WITH_CXX11_ABI} == '1' ]]; then
+        CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
+    fi
 fi
 
 CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include"

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -136,10 +136,11 @@ if [ $(uname) == "Darwin" ]; then
     export DYLIB="dylib"
     LINKER_FLAGS="-L${PREFIX}/lib"
 else
-    CC=${PREFIX}/bin/gcc
-    CXX=${PREFIX}/bin/g++
+    CC=gcc
+    CXX=g++
     export DYLIB="so"
     LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
+    CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0 ${CXXFLAGS}"
 fi
 
 CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include"

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -30,7 +30,7 @@ source:
   path: ../
 
 build:
-  number: 0
+  number: 1
   string: py{{CONDA_PY}}_{{PKG_BUILDNUM}}_g{{GIT_FULL_HASH[:7]}}
 
   script_env:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,7 +43,6 @@ build:
 
 requirements:
   build:
-    - gcc 4.8.5 # [linux]
     - patchelf # [linux]
     - hdf5 1.10.1
     - boost 1.55.0 # [py2k]
@@ -60,7 +59,6 @@ requirements:
     {% endif %}
 
   run:
-    - libgcc 4.8.5 # [linux]
     - patchelf # [linux]
     - hdf5 1.10.1
     - boost 1.55.0 # [py2k]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,6 +40,7 @@ build:
     - WITH_GUROBI
     - GUROBI_ROOT_DIR
     - GUROBI_LIB_WIN # [win]
+    - DO_NOT_BUILD_WITH_CXX11_ABI  # [linux]
 
 requirements:
   build:


### PR DESCRIPTION
This is related to allowing dependencies to be built with newer gcc than the one available through conda (4.8.5 atm), in particular, recent nifty changes forced us to use a newer compiler.

See some more background on this in https://github.com/ilastik/ilastik-publish-packages/issues/2

In order to use the system compilers this PR removes

* references to `gcc`, `libgcc` in the respective `meta.yaml` files
* points to the correct compiler in `build.sh`
* introduces an environment variable `DO_NOT_BUILD_WITH_CXX11_ABI` that is used in the build process to enable building with `-D_GLIBCXX_USE_CXX11_ABI=0` to enable compatibility with the "old" gcc stdlib abi.