### PR TITLE
Fixes for new conda compilers and gurobi 811

### DIFF
--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -40,8 +40,8 @@ REM ----------------------------------------------------------------------
 set CONFIGURATION=Release
 
 cmake .. -G "%CMAKE_GENERATOR%" -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
     -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%"  ^
-    -DBOOST_ROOT="%LIBRARY%" ^
     -DCMAKE_CXX_FLAGS="-DBOOST_ALL_NO_LIB /EHsc" ^
     ^
     %OPTIMIZER_ARGS% ^

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -109,9 +109,9 @@ else
         #       We use clang now so we use the libc++ version.
         GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_CXX_LIBRARY=${GUROBI_ROOT_DIR}/lib/libgurobi_c++.a"
     else
-        # Only one choice on Linux. It works with libstdc++ (from the GNU people).
-        # (The naming convention isn't consistent with the name on Mac, but that's okay.)
-        GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_CXX_LIBRARY=${GUROBI_ROOT_DIR}/lib/libgurobi_c++.a"
+        # we have to specify the lib that was built using the new cxx abi. With
+        # gurobi 8.1.1 it is libgurobi_g++5.2.a
+        GUROBI_ARGS="${GUROBI_ARGS} -DGUROBI_CXX_LIBRARY=${GUROBI_ROOT_DIR}/lib/libgurobi_g++5.2.a"
     fi
 
     SUFFIX="_with_gurobi"

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -126,9 +126,8 @@ cd build
 
 if [ $(uname) == "Darwin" ]; then
     CXXFLAGS="-std=c++11 -stdlib=libc++"
-    
-    export DYLIB="dylib"
-    LINKER_FLAGS="-L${PREFIX}/lib"
+    LDFLAGS="-undefined dynamic_lookup ${LDFLAGS}"
+    LDFLAGS="-L${PREFIX}/lib ${LDFLAGS}"
 else
     LDFLAGS="-Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
 fi

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,11 +1,9 @@
 boost:
-  - 1.63.0
+  - 1.68.0
 hdf5:
-  - 1.10.1
-libstdcxxng:
-  - 5.4.0
+  - 1.10.4
 python:
-  - 3.6
+  - 3.7
 
 
 pin_run_as_build:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -43,7 +43,10 @@ build:
 
 requirements:
   build:
+    - cmake
+    - {{ compiler("cxx") }}
     - patchelf # [linux]
+  host:
     - hdf5 {{ hdf5 }}
     - boost {{ boost }}
     - opengm-structured-learning-headers
@@ -56,7 +59,6 @@ requirements:
     {% if WITH_GUROBI == 1 %}
     - gurobi-symlink # [not win]
     {% endif %}
-
   run:
     - patchelf # [linux]
     - hdf5

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,14 +40,12 @@ build:
     - WITH_GUROBI
     - GUROBI_ROOT_DIR
     - GUROBI_LIB_WIN # [win]
-    - DO_NOT_BUILD_WITH_CXX11_ABI  # [linux]
 
 requirements:
   build:
     - patchelf # [linux]
     - hdf5 {{ hdf5 }}
-    - boost 1.55.0 # [py2k]
-    - boost {{ boost }} # [py3k]
+    - boost {{ boost }}
     - opengm-structured-learning-headers
     - python {{ python }}
 
@@ -62,10 +60,7 @@ requirements:
   run:
     - patchelf # [linux]
     - hdf5
-    # in order to support older linux distros after gcc5 switch:
-    - libstdcxx-ng >={{ libstdcxxng }}  # [linux]
-    - boost 1.55.0 # [py2k]
-    - boost  # [py3k]
+    - boost
     - python
 
     {% if WITH_CPLEX == 1 %}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 message( "\nConfiguring python wrapper:" )
 
 # dependencies
-find_package( Boost REQUIRED COMPONENTS python serialization )
+find_package( Boost REQUIRED COMPONENTS python37 serialization )
 find_package( PythonInterp REQUIRED )
 
 if(WIN32)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -34,7 +34,16 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pymultiHypoTracking.cpp.cmake ${CMAKE
 set(PYMULTIHYPOTRACKING_SRCS ${CMAKE_CURRENT_BINARY_DIR}/pymultiHypoTracking.cpp pythonmodel.cpp)
 
 add_library(pymultiHypoTracking${SUFFIX} SHARED ${PYMULTIHYPOTRACKING_SRCS})#
-target_link_libraries(pymultiHypoTracking${SUFFIX} multiHypoTracking${SUFFIX} ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} )
+# building with the "new" conda compilers resulted in strange test errors
+# like: TypeError: Expecting an object of type dict; got an object of type dict instead
+# Solution is not to link against python during the build
+# See: https://github.com/casacore/python-casacore/issues/144
+if(APPLE)
+  target_link_libraries(pymultiHypoTracking${SUFFIX} multiHypoTracking${SUFFIX} ${Boost_LIBRARIES} )
+else()
+  target_link_libraries(pymultiHypoTracking${SUFFIX} multiHypoTracking${SUFFIX} ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} )
+endif()
+
 if(WIN32)
   set_target_properties(pymultiHypoTracking${SUFFIX} PROPERTIES PREFIX "" OUTPUT_NAME "multiHypoTracking${SUFFIX}" SUFFIX ".pyd")
 else()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 2.8)
 message( "\nConfiguring python wrapper:" )
 
-# dependencies
-find_package( Boost REQUIRED COMPONENTS python37 serialization )
+# dependencies; python major, minor version seem to be required with boost>=1.68 on win
+# disclaimer, did not try other python versions
+find_package( Boost REQUIRED COMPONENTS python${Python_VERSION_MAJOR}${Python_VERSION_MINOR} serialization )
 find_package( PythonInterp REQUIRED )
 
 if(WIN32)


### PR DESCRIPTION
Summary:
* cleanup of the conda recipe
* need to specify `libgurobi_g++5.2.a` explicitly in order to build with the new abi (default links to the old one) on linux
* do not link against python on mac -> `-undefined dynamic_lookup`